### PR TITLE
KBE-533:Message for second and any wrong attempt of OTP after first a…

### DIFF
--- a/core/platform-common/src/main/java/org/sunbird/exception/ResponseMessage.java
+++ b/core/platform-common/src/main/java/org/sunbird/exception/ResponseMessage.java
@@ -111,7 +111,7 @@ public interface ResponseMessage {
     String EXTENDED_USER_PROFILE_NOT_LOADED = "Failed to load extendedProfileSchemaConfig from System_Settings table";
     String ROLE_PROCESSING_INVALID_ORG = "Error while processing assign role. Invalid Organisation Id";
     String ERROR_OTP_EXPIRED = "Time Limit for OTP Exceeded, Please Try Again.";
-    String ERROR_OTP_ATTEMPT_EXCEEDED = "Number of attempts exceeded for OTP verification. Please try again.";;
+    String ERROR_OTP_ATTEMPT_EXCEEDED = "The maximum number of attempts for OTP verification has been exceeded. Please try again after 15 minutes";
   }
 
   interface Key {


### PR DESCRIPTION
KBE - 533 | Message for second and any wrong attempt of OTP after first attempt is displayed wrong
Change in Response Message to : ERROR_OTP_ATTEMPT_EXCEEDED = "The maximum number of attempts for OTP verification has been exceeded. Please try again after 15 minutes"